### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Introduction
     :target: https://adafru.it/discord
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_BNO055.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_BNO055
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_BNO055.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_BNO055
     :alt: Build Status
 
 


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.