### PR TITLE
mode setter enables changes and honors delays.

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -199,7 +199,7 @@ class BNO055:
 
     @mode.setter
     def mode(self, new_mode):
-        self._write_register(_MODE_REGISTER, _CONFIG_MODE)  # Empirically necessary
+        self._write_register(_MODE_REGISTER, CONFIG_MODE)  # Empirically necessary
         time.sleep(0.02)  # Datasheet table 3.6
         if new_mode != CONFIG_MODE:
             self._write_register(_MODE_REGISTER, new_mode)

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -197,6 +197,14 @@ class BNO055:
         """
         return self._read_register(_MODE_REGISTER)
 
+    @mode.setter
+    def mode(self, new_mode):
+        self._write_register(_MODE_REGISTER, _CONFIG_MODE)  # Empirically necessary
+        time.sleep_ms(0.02)  # Datasheet table 3.6
+        if new_mode != _CONFIG_MODE:
+            self._write_register(_MODE_REGISTER, new_mode)
+            time.sleep(0.01)  # Table 3.6
+
     @property
     def calibration_status(self):
         """Tuple containing sys, gyro, accel, and mag calibration data."""
@@ -212,10 +220,6 @@ class BNO055:
         """Boolean indicating calibration status."""
         sys, gyro, accel, mag = self.calibration_status
         return sys == gyro == accel == mag == 0x03
-
-    @mode.setter
-    def mode(self, new_mode):
-        self._write_register(_MODE_REGISTER, new_mode)
 
     @property
     def external_crystal(self):

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -200,8 +200,8 @@ class BNO055:
     @mode.setter
     def mode(self, new_mode):
         self._write_register(_MODE_REGISTER, _CONFIG_MODE)  # Empirically necessary
-        time.sleep_ms(0.02)  # Datasheet table 3.6
-        if new_mode != _CONFIG_MODE:
+        time.sleep(0.02)  # Datasheet table 3.6
+        if new_mode != CONFIG_MODE:
             self._write_register(_MODE_REGISTER, new_mode)
             time.sleep(0.01)  # Table 3.6
 


### PR DESCRIPTION
This fixes two issues with the mode setter.

Firstly, as per issue #26, it is necessary to set `_CONFIG_MODE` prior to making any other mode change. The datasheet is misleading on this but it is empirically necessary.

Secondly the datasheet mandates delays after setting and clearing `_CONFIG_MODE`.

Please note that I have no means of running CircuitPython: I have tested this code against MicroPython only.