### PR TITLE
Add calibration offsets and radii as properties on BNO055 library

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -100,12 +100,15 @@ class _ModeStruct(Struct): # pylint: disable=too-few-public-methods
         obj.mode = self.mode
         result = super().__get__(obj, objtype)
         obj.mode = last_mode
-        return result
+        # single value comes back as a one-element tuple
+        return result[0] if type(result) == tuple and len(result) == 1 else result
 
     def __set__(self, obj, value):
         last_mode = obj.mode
         obj.mode = self.mode
-        super().__set__(obj, value)
+        # underlying __set__() expects a tuple
+        set_val = (value,) if type(value) != tuple else value
+        super().__set__(obj, set_val)
         obj.mode = last_mode
 
 class BNO055:

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -107,7 +107,6 @@ class _ModeStruct(Struct): # pylint: disable=too-few-public-methods
         obj.mode = self.mode
         super().__set__(obj, value)
         obj.mode = last_mode
-        time.sleep(0.01)
 
 class BNO055:
     """

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -101,13 +101,13 @@ class _ModeStruct(Struct): # pylint: disable=too-few-public-methods
         result = super().__get__(obj, objtype)
         obj.mode = last_mode
         # single value comes back as a one-element tuple
-        return result[0] if type(result) == tuple and len(result) == 1 else result
+        return result[0] if isinstance(result, tuple) and len(result) == 1 else result
 
     def __set__(self, obj, value):
         last_mode = obj.mode
         obj.mode = self.mode
         # underlying __set__() expects a tuple
-        set_val = (value,) if type(value) != tuple else value
+        set_val = value if isinstance(value, tuple) else (value,)
         super().__set__(obj, set_val)
         obj.mode = last_mode
 

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -62,6 +62,11 @@ _POWER_SUSPEND = const(0x02)
 _MODE_REGISTER = const(0x3d)
 _PAGE_REGISTER = const(0x07)
 _CALIBRATION_REGISTER = const(0x35)
+_OFFSET_ACCEL_REGISTER = const(0x55)
+_OFFSET_MAGNET_REGISTER = const(0x5b)
+_OFFSET_GYRO_REGISTER = const(0x61)
+_RADIUS_ACCEL_REGISTER = const(0x67)
+_RADIUS_MAGNET_REGISTER = const(0x69)
 _TRIGGER_REGISTER = const(0x3f)
 _POWER_REGISTER = const(0x3e)
 _ID_REGISTER = const(0x00)
@@ -212,6 +217,52 @@ class BNO055:
         """Boolean indicating calibration status."""
         sys, gyro, accel, mag = self.calibration_status
         return sys == gyro == accel == mag == 0x03
+
+    _offsets_accelerometer = Struct(_OFFSET_ACCEL_REGISTER, '<hhh')
+    _offsets_magnetometer = Struct(_OFFSET_MAGNET_REGISTER, '<hhh')
+    _offsets_gyroscope = Struct(_OFFSET_GYRO_REGISTER, '<hhh')
+    _radius_accelerometer = Struct(_RADIUS_ACCEL_REGISTER, '<h')
+    _radius_magnetometer = Struct(_RADIUS_MAGNET_REGISTER, '<h')
+
+    @property
+    def offsets_accelerometer(self):
+        last_mode = self.mode
+        self.mode = CONFIG_MODE
+        vector = self._offsets_accelerometer
+        self.mode = last_mode
+        return vector
+
+    @property
+    def offsets_magnetometer(self):
+        last_mode = self.mode
+        self.mode = CONFIG_MODE
+        vector = self._offsets_magnetometer
+        self.mode = last_mode
+        return vector
+
+    @property
+    def offsets_gyroscope(self):
+        last_mode = self.mode
+        self.mode = CONFIG_MODE
+        vector = self._offsets_gyroscope
+        self.mode = last_mode
+        return vector
+
+    @property
+    def radius_accelerometer(self):
+        last_mode = self.mode
+        self.mode = CONFIG_MODE
+        vector = self._radius_accelerometer
+        self.mode = last_mode
+        return vector[0]
+
+    @property
+    def radius_magnetometer(self):
+        last_mode = self.mode
+        self.mode = CONFIG_MODE
+        vector = self._radius_magnetometer
+        self.mode = last_mode
+        return vector[0]
 
     @mode.setter
     def mode(self, new_mode):

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -226,6 +226,7 @@ class BNO055:
 
     @property
     def offsets_accelerometer(self):
+        """Returns a 3-value Struct with the (x, y, z) accelerometer calibration offsets"""
         last_mode = self.mode
         self.mode = CONFIG_MODE
         vector = self._offsets_accelerometer
@@ -234,6 +235,7 @@ class BNO055:
 
     @property
     def offsets_magnetometer(self):
+        """Returns a 3-value Struct with the (x, y, z) magnetometer calibration offsets"""
         last_mode = self.mode
         self.mode = CONFIG_MODE
         vector = self._offsets_magnetometer
@@ -242,6 +244,7 @@ class BNO055:
 
     @property
     def offsets_gyroscope(self):
+        """Returns a 3-value Struct with the (x, y, z) gyroscope calibration offsets"""
         last_mode = self.mode
         self.mode = CONFIG_MODE
         vector = self._offsets_gyroscope
@@ -250,6 +253,7 @@ class BNO055:
 
     @property
     def radius_accelerometer(self):
+        """Returns the current accelerometer calibration radius"""
         last_mode = self.mode
         self.mode = CONFIG_MODE
         vector = self._radius_accelerometer
@@ -258,6 +262,7 @@ class BNO055:
 
     @property
     def radius_magnetometer(self):
+        """Returns the current magnetometer calibration radius"""
         last_mode = self.mode
         self.mode = CONFIG_MODE
         vector = self._radius_magnetometer


### PR DESCRIPTION
issue #21 

builds on work by @katlings and replaces [her PR](https://github.com/adafruit/Adafruit_CircuitPython_BNO055/pull/22)
implements the approach suggested by @deshipu and addresses feedback from @caternuson

note - assignment is fighting against BNO055 auto-calibration so can have odd behavior

```
Adafruit CircuitPython 4.0.0-rc.1 on 2019-04-23; Adafruit Feather M4 Express with samd51j19
>>> import board, busio
>>> import adafruit_bno055 as bno055
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> bno = bno055.BNO055(i2c)
>>> bno.radius_magnetometer
0
>>> bno.radius_magnetometer = 40
>>> bno.radius_magnetometer = 40
>>> bno.radius_magnetometer
1
>>> bno.radius_magnetometer
0
>>> bno.offsets_accelerometer = 1, -1, 1
>>> bno.offsets_accelerometer
(1, -1, 1)
```
