### PR TITLE
Change to gyro and rads/sec

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -108,7 +108,12 @@ class BNO055:
     magnetic = _ScaledReadOnlyStruct(0x0e, '<hhh', 1/16)
     """Gives the raw magnetometer readings in microteslas."""
     gyroscope = _ScaledReadOnlyStruct(0x14, '<hhh', 1/16)
-    """Gives the raw gyroscope reading in degrees per second."""
+    """Gives the raw gyroscope reading in degrees per second.
+
+       .. warning:: This is deprecated. Use ``gyro`` instead. It'll work with
+         other drivers too."""
+    gyro = _ScaledReadOnlyStruct(0x14, '<hhh', 0.001090830782496456)
+    """Gives the raw gyroscope reading in radians per second."""
     euler = _ScaledReadOnlyStruct(0x1a, '<hhh', 1/16)
     """Gives the calculated orientation angles, in degrees."""
     quaternion = _ScaledReadOnlyStruct(0x20, '<hhhh', 1/(1<<14))

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -10,7 +10,7 @@ while True:
     print('Temperature: {} degrees C'.format(sensor.temperature))
     print('Accelerometer (m/s^2): {}'.format(sensor.accelerometer))
     print('Magnetometer (microteslas): {}'.format(sensor.magnetometer))
-    print('Gyroscope (deg/sec): {}'.format(sensor.gyroscope))
+    print('Gyroscope (rad/sec): {}'.format(sensor.gyro))
     print('Euler angle: {}'.format(sensor.euler))
     print('Quaternion: {}'.format(sensor.quaternion))
     print('Linear acceleration (m/s^2): {}'.format(sensor.linear_acceleration))


### PR DESCRIPTION
For #34.

- Had to bury the math in the scale parameter. Couldn't just math on the `_ScaledReadOnlyStruct` class. Decided not to import `math` just for `pi`.
- Marked `gyroscope` as deprecated
- Updated `bno055_simpletest.py` example
- webgl example is OK as is, doesn't seem to use gyro
- Tested with Itsy M4 and updated `bno055_simpletest.py`