### PR TITLE
Add UART support

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -233,6 +233,10 @@ class BNO055:
         return self._temperature
 
     @property
+    def _temperature(self):
+        raise NotImplementedError("Must be implemented.")
+
+    @property
     def acceleration(self):
         """Gives the raw accelerometer readings, in m/s.
         Returns an empty tuple of length 3 when this property has been disabled by the current mode.
@@ -240,6 +244,10 @@ class BNO055:
         if self.mode not in [0x00, 0x02, 0x03, 0x06]:
             return self._acceleration
         return (None, None, None)
+
+    @property
+    def _acceleration(self):
+        raise NotImplementedError("Must be implemented.")
 
     @property
     def magnetic(self):
@@ -251,6 +259,10 @@ class BNO055:
         return (None, None, None)
 
     @property
+    def _magnetic(self):
+        raise NotImplementedError("Must be implemented.")
+
+    @property
     def gyro(self):
         """Gives the raw gyroscope reading in radians per second.
         Returns an empty tuple of length 3 when this property has been disabled by the current mode.
@@ -258,6 +270,10 @@ class BNO055:
         if self.mode not in [0x00, 0x01, 0x02, 0x04, 0x09, 0x0A]:
             return self._gyro
         return (None, None, None)
+
+    @property
+    def _gyro(self):
+        raise NotImplementedError("Must be implemented.")
 
     @property
     def euler(self):
@@ -269,6 +285,10 @@ class BNO055:
         return (None, None, None)
 
     @property
+    def _euler(self):
+        raise NotImplementedError("Must be implemented.")
+
+    @property
     def quaternion(self):
         """Gives the calculated orientation as a quaternion.
         Returns an empty tuple of length 3 when this property has been disabled by the current mode.
@@ -276,6 +296,10 @@ class BNO055:
         if self.mode in [0x09, 0x0B, 0x0C]:
             return self._quaternion
         return (None, None, None, None)
+
+    @property
+    def _quaternion(self):
+        raise NotImplementedError("Must be implemented.")
 
     @property
     def linear_acceleration(self):
@@ -287,6 +311,10 @@ class BNO055:
         return (None, None, None)
 
     @property
+    def _linear_acceleration(self):
+        raise NotImplementedError("Must be implemented.")
+
+    @property
     def gravity(self):
         """Returns the gravity vector, without acceleration in m/s.
         Returns an empty tuple of length 3 when this property has been disabled by the current mode.
@@ -294,6 +322,10 @@ class BNO055:
         if self.mode in [0x09, 0x0B, 0x0C]:
             return self._gravity
         return (None, None, None)
+
+    @property
+    def _gravity(self):
+        raise NotImplementedError("Must be implemented.")
 
     def _write_register(self, register, value):
         raise NotImplementedError("Must be implemented.")
@@ -356,7 +388,7 @@ class BNO055_UART(BNO055):
         self._uart.baudrate = 115200
         super().__init__()
 
-    def _write_register(self, register, data):
+    def _write_register(self, register, data):  # pylint: disable=arguments-differ
         if not isinstance(data, bytes):
             data = bytes([data])
         self._uart.write(bytes([0xAA, 0x00, register, len(data)]) + data)
@@ -367,7 +399,7 @@ class BNO055_UART(BNO055):
         if resp[0] != 0xEE or resp[1] != 0x01:
             raise RuntimeError("UART write error: {}".format(resp[1]))
 
-    def _read_register(self, register, length=1):
+    def _read_register(self, register, length=1):  # pylint: disable=arguments-differ
         self._uart.write(bytes([0xAA, 0x01, register, length]))
         time.sleep(0.1)
         resp = self._uart.read(self._uart.in_waiting)

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -72,6 +72,7 @@ _TRIGGER_REGISTER = const(0x3F)
 _POWER_REGISTER = const(0x3E)
 _ID_REGISTER = const(0x00)
 
+
 class _ScaledReadOnlyStruct(Struct):  # pylint: disable=too-few-public-methods
     def __init__(self, register_address, struct_format, scale):
         super(_ScaledReadOnlyStruct, self).__init__(register_address, struct_format)
@@ -300,6 +301,7 @@ class BNO055:
     def _read_register(self, register):
         raise NotImplementedError("Must be implemented.")
 
+
 class BNO055_I2C(BNO055):
     """
     Driver for the BNO055 9DOF IMU sensor via I2C.
@@ -348,13 +350,16 @@ class BNO055_UART(BNO055):
     """
     Driver for the BNO055 9DOF IMU sensor via UART.
     """
+
     def __init__(self, uart):
         self._uart = uart
         self._uart.baudrate = 115200
         super().__init__()
 
-    def _write_register(self, register, value):
-        self._uart.write(bytes([0xAA, 0x00, register, 0x01, value]))
+    def _write_register(self, register, data):
+        if not isinstance(data, bytes):
+            data = bytes([data])
+        self._uart.write(bytes([0xAA, 0x00, register, len(data)]) + data)
         time.sleep(0.1)
         resp = self._uart.read(self._uart.in_waiting)
         if len(resp) < 2:
@@ -381,46 +386,89 @@ class BNO055_UART(BNO055):
     @property
     def _acceleration(self):
         resp = struct.unpack("<hhh", self._read_register(0x08, 6))
-        return  tuple([x / 100 for x in resp])
+        return tuple([x / 100 for x in resp])
 
     @property
     def _magnetic(self):
         resp = struct.unpack("<hhh", self._read_register(0x0E, 6))
-        return  tuple([x / 16 for x in resp])
+        return tuple([x / 16 for x in resp])
 
     @property
     def _gyro(self):
         resp = struct.unpack("<hhh", self._read_register(0x0E, 6))
-        return  tuple([x * 0.001090830782496456 for x in resp])
+        return tuple([x * 0.001090830782496456 for x in resp])
 
     @property
     def _euler(self):
         resp = struct.unpack("<hhh", self._read_register(0x1A, 6))
-        return  tuple([x / 16 for x in resp])
+        return tuple([x / 16 for x in resp])
 
     @property
     def _quaternion(self):
         resp = struct.unpack("<hhhh", self._read_register(0x20, 8))
-        return  tuple([x / (1 << 14) for x in resp])
+        return tuple([x / (1 << 14) for x in resp])
 
     @property
     def _linear_acceleration(self):
         resp = struct.unpack("<hhh", self._read_register(0x28, 6))
-        return  tuple([x / 100 for x in resp])
+        return tuple([x / 100 for x in resp])
 
     @property
     def _gravity(self):
         resp = struct.unpack("<hhh", self._read_register(0x2E, 6))
-        return  tuple([x / 100 for x in resp])
+        return tuple([x / 100 for x in resp])
 
-    # offsets_accelerometer = _ModeStruct(_OFFSET_ACCEL_REGISTER, "<hhh", CONFIG_MODE)
-    # """Calibration offsets for the accelerometer"""
-    # offsets_magnetometer = _ModeStruct(_OFFSET_MAGNET_REGISTER, "<hhh", CONFIG_MODE)
-    # """Calibration offsets for the magnetometer"""
-    # offsets_gyroscope = _ModeStruct(_OFFSET_GYRO_REGISTER, "<hhh", CONFIG_MODE)
-    # """Calibration offsets for the gyroscope"""
+    @property
+    def offsets_accelerometer(self):
+        """Calibration offsets for the accelerometer"""
+        return struct.unpack("<hhh", self._read_register(_OFFSET_ACCEL_REGISTER, 6))
 
-    # radius_accelerometer = _ModeStruct(_RADIUS_ACCEL_REGISTER, "<h", CONFIG_MODE)
-    # """Radius for accelerometer (cm?)"""
-    # radius_magnetometer = _ModeStruct(_RADIUS_MAGNET_REGISTER, "<h", CONFIG_MODE)
-    # """Radius for magnetometer (cm?)"""
+    @offsets_accelerometer.setter
+    def offsets_accelerometer(self, offsets):
+        data = bytearray(6)
+        struct.pack_into("<hhh", data, 0, *offsets)
+        self._write_register(_OFFSET_ACCEL_REGISTER, bytes(data))
+
+    @property
+    def offsets_magnetometer(self):
+        """Calibration offsets for the magnetometer"""
+        return struct.unpack("<hhh", self._read_register(_OFFSET_MAGNET_REGISTER, 6))
+
+    @offsets_magnetometer.setter
+    def offsets_magnetometer(self, offsets):
+        data = bytearray(6)
+        struct.pack_into("<hhh", data, 0, *offsets)
+        self._write_register(_OFFSET_MAGNET_REGISTER, bytes(data))
+
+    @property
+    def offsets_gyroscope(self):
+        """Calibration offsets for the gyroscope"""
+        return struct.unpack("<hhh", self._read_register(_OFFSET_GYRO_REGISTER, 6))
+
+    @offsets_gyroscope.setter
+    def offsets_gyroscope(self, offsets):
+        data = bytearray(6)
+        struct.pack_into("<hhh", data, 0, *offsets)
+        self._write_register(_OFFSET_GYRO_REGISTER, bytes(data))
+
+    @property
+    def radius_accelerometer(self):
+        """Radius for accelerometer (cm?)"""
+        return struct.unpack("<h", self._read_register(_RADIUS_ACCEL_REGISTER, 2))[0]
+
+    @radius_accelerometer.setter
+    def radius_accelerometer(self, radius):
+        data = bytearray(2)
+        struct.pack_into("<h", data, 0, radius)
+        self._write_register(_RADIUS_ACCEL_REGISTER, bytes(data))
+
+    @property
+    def radius_magnetometer(self):
+        """Radius for magnetometer (cm?)"""
+        return struct.unpack("<h", self._read_register(_RADIUS_MAGNET_REGISTER, 2))[0]
+
+    @radius_magnetometer.setter
+    def radius_magnetometer(self, radius):
+        data = bytearray(2)
+        struct.pack_into("<h", data, 0, radius)
+        self._write_register(_RADIUS_MAGNET_REGISTER, bytes(data))

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -3,8 +3,13 @@ import board
 import busio
 import adafruit_bno055
 
+# Use these lines for I2C
 i2c = busio.I2C(board.SCL, board.SDA)
 sensor = adafruit_bno055.BNO055_I2C(i2c)
+
+# User these lines for UART
+#uart = busio.UART(board.TX, board.RX)
+#sensor = adafruit_bno055.BNO055_UART(uart)
 
 while True:
     print("Temperature: {} degrees C".format(sensor.temperature))

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -8,8 +8,8 @@ i2c = busio.I2C(board.SCL, board.SDA)
 sensor = adafruit_bno055.BNO055_I2C(i2c)
 
 # User these lines for UART
-#uart = busio.UART(board.TX, board.RX)
-#sensor = adafruit_bno055.BNO055_UART(uart)
+# uart = busio.UART(board.TX, board.RX)
+# sensor = adafruit_bno055.BNO055_UART(uart)
 
 while True:
     print("Temperature: {} degrees C".format(sensor.temperature))

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -4,7 +4,7 @@ import busio
 import adafruit_bno055
 
 i2c = busio.I2C(board.SCL, board.SDA)
-sensor = adafruit_bno055.BNO055(i2c)
+sensor = adafruit_bno055.BNO055_I2C(i2c)
 
 while True:
     print("Temperature: {} degrees C".format(sensor.temperature))

--- a/examples/bno055_webgl_demo/server.py
+++ b/examples/bno055_webgl_demo/server.py
@@ -40,7 +40,7 @@ import adafruit_bno055
 i2c = busio.I2C(board.SCL, board.SDA)
 
 # Create the BNO sensor connection.
-bno = adafruit_bno055.BNO055(i2c)
+bno = adafruit_bno055.BNO055_I2C(i2c)
 
 # Application configuration below.  You probably don't need to change these values.
 


### PR DESCRIPTION
For #41 

**BREAKING CHANGE**

- Adds UART support
- Classes refactored into base and I2C/UART specific subs
- examples updated

Tested on Itsy M4.

![bno_uart_test](https://user-images.githubusercontent.com/8755041/79804146-4a772f00-8318-11ea-830d-45ff1825a3e5.jpg)

```python
Adafruit CircuitPython 5.1.0 on 2020-04-02; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board
>>> import adafruit_bno055
>>> bno = adafruit_bno055.BNO055_UART(board.UART())
>>> bno.acceleration
(0.12, -0.43, 9.99)
>>> bno.acceleration
(0.06, -8.53, 5.27)
>>> bno.acceleration
(-3.65, 8.36, 1.48)
>>> bno.acceleration
(-8.49, -4.86, -1.55)
>>> 
```
