### PR TITLE
Register reference fix for GYR_DATA_X_LSB

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -427,7 +427,7 @@ class BNO055_UART(BNO055):
 
     @property
     def _gyro(self):
-        resp = struct.unpack("<hhh", self._read_register(0x0E, 6))
+        resp = struct.unpack("<hhh", self._read_register(0x14, 6))
         return tuple([x * 0.001090830782496456 for x in resp])
 
     @property


### PR DESCRIPTION
Changing _gyro property from incorrect magnetic register address from MAG_DATA_X_LSB 0x0E to gyro address  GYR_DATA_X_LSB 0x14