### PR TITLE
Allow uart to go ~100Hz versus 10Hz

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -408,7 +408,7 @@ class BNO055_UART(BNO055):
             pass
         resp = self._uart.read(self._uart.in_waiting)
 
-        if resp[0] != 0xBB: # Recursion
+        if resp[0] != 0xBB:  # Recursion
             self._uart.write(bytes([0xAA, 0x01, register, length]))
             now = time.time()
             while self._uart.in_waiting < length + 2 and time.time() - now < 0.25:

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -410,7 +410,7 @@ class BNO055_UART(BNO055):
                 pass
             resp = self._uart.read(self._uart.in_waiting)
             if len(resp) >= 2 and resp[0] == 0xBB:
-                i = 3
+                break
             i += 1
         if len(resp) < 2:
             raise OSError("UART access error.")

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -392,7 +392,7 @@ class BNO055_UART(BNO055):
         if not isinstance(data, bytes):
             data = bytes([data])
         self._uart.write(bytes([0xAA, 0x00, register, len(data)]) + data)
-        time.sleep(0.1)
+        time.sleep(0.01)
         resp = self._uart.read(self._uart.in_waiting)
         if len(resp) < 2:
             raise OSError("UART access error.")
@@ -401,7 +401,7 @@ class BNO055_UART(BNO055):
 
     def _read_register(self, register, length=1):  # pylint: disable=arguments-differ
         self._uart.write(bytes([0xAA, 0x01, register, length]))
-        time.sleep(0.1)
+        time.sleep(0.01)
         resp = self._uart.read(self._uart.in_waiting)
         if len(resp) < 2:
             raise OSError("UART access error.")

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -392,8 +392,8 @@ class BNO055_UART(BNO055):
         if not isinstance(data, bytes):
             data = bytes([data])
         self._uart.write(bytes([0xAA, 0x00, register, len(data)]) + data)
-        now = time.time()
-        while self._uart.in_waiting < 2 and time.time() - now < 0.25:
+        now = time.monotonic()
+        while self._uart.in_waiting < 2 and time.monotonic() - now < 0.25:
             pass
         resp = self._uart.read(self._uart.in_waiting)
         if len(resp) < 2:
@@ -403,15 +403,15 @@ class BNO055_UART(BNO055):
 
     def _read_register(self, register, length=1):  # pylint: disable=arguments-differ
         self._uart.write(bytes([0xAA, 0x01, register, length]))
-        now = time.time()
-        while self._uart.in_waiting < length + 2 and time.time() - now < 0.25:
+        now = time.monotonic()
+        while self._uart.in_waiting < length + 2 and time.monotonic() - now < 0.25:
             pass
         resp = self._uart.read(self._uart.in_waiting)
 
         if resp[0] != 0xBB:  # Recursion
             self._uart.write(bytes([0xAA, 0x01, register, length]))
-            now = time.time()
-            while self._uart.in_waiting < length + 2 and time.time() - now < 0.25:
+            now = time.monotonic()
+            while self._uart.in_waiting < length + 2 and time.monotonic() - now < 0.25:
                 pass
             resp = self._uart.read(self._uart.in_waiting)
             if len(resp) < 2:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,11 +10,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.viewcode",
-]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.viewcode"]
 
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
@@ -144,7 +140,7 @@ latex_documents = [
         "Adafruit BNO055 Library Documentation",
         "Radomir Dopieralski",
         "manual",
-    ),
+    )
 ]
 
 # -- Options for manual page output ---------------------------------------
@@ -175,5 +171,5 @@ texinfo_documents = [
         "AdafruitBNO055Library",
         "One line description of project.",
         "Miscellaneous",
-    ),
+    )
 ]

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -12,6 +12,7 @@ sensor = adafruit_bno055.BNO055_I2C(i2c)
 # sensor = adafruit_bno055.BNO055_UART(uart)
 
 while True:
+    print("Temperature: {} degrees C".format(sensor.temperature))
     print("Accelerometer (m/s^2): {}".format(sensor.acceleration))
     print("Magnetometer (microteslas): {}".format(sensor.magnetic))
     print("Gyroscope (rad/sec): {}".format(sensor.gyro))

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -12,14 +12,17 @@ sensor = adafruit_bno055.BNO055_I2C(i2c)
 # sensor = adafruit_bno055.BNO055_UART(uart)
 
 while True:
-    print("Temperature: {} degrees C".format(sensor.temperature))
-    print("Accelerometer (m/s^2): {}".format(sensor.acceleration))
-    print("Magnetometer (microteslas): {}".format(sensor.magnetic))
-    print("Gyroscope (rad/sec): {}".format(sensor.gyro))
-    print("Euler angle: {}".format(sensor.euler))
-    print("Quaternion: {}".format(sensor.quaternion))
-    print("Linear acceleration (m/s^2): {}".format(sensor.linear_acceleration))
-    print("Gravity (m/s^2): {}".format(sensor.gravity))
-    print()
+    # Try/except only necessary when usuing UART mode
+    try:
+        print("Accelerometer (m/s^2): {}".format(sensor.acceleration))
+        print("Magnetometer (microteslas): {}".format(sensor.magnetic))
+        print("Gyroscope (rad/sec): {}".format(sensor.gyro))
+        print("Euler angle: {}".format(sensor.euler))
+        print("Quaternion: {}".format(sensor.quaternion))
+        print("Linear acceleration (m/s^2): {}".format(sensor.linear_acceleration))
+        print("Gravity (m/s^2): {}".format(sensor.gravity))
+        print()
+    except RuntimeError:
+        continue
 
     time.sleep(1)

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -22,7 +22,7 @@ while True:
         print("Linear acceleration (m/s^2): {}".format(sensor.linear_acceleration))
         print("Gravity (m/s^2): {}".format(sensor.gravity))
         print()
-    except RuntimeError:
-        continue
+    except RuntimeError as e:
+        print(e)
 
     time.sleep(1)

--- a/examples/bno055_simpletest.py
+++ b/examples/bno055_simpletest.py
@@ -12,17 +12,13 @@ sensor = adafruit_bno055.BNO055_I2C(i2c)
 # sensor = adafruit_bno055.BNO055_UART(uart)
 
 while True:
-    # Try/except only necessary when usuing UART mode
-    try:
-        print("Accelerometer (m/s^2): {}".format(sensor.acceleration))
-        print("Magnetometer (microteslas): {}".format(sensor.magnetic))
-        print("Gyroscope (rad/sec): {}".format(sensor.gyro))
-        print("Euler angle: {}".format(sensor.euler))
-        print("Quaternion: {}".format(sensor.quaternion))
-        print("Linear acceleration (m/s^2): {}".format(sensor.linear_acceleration))
-        print("Gravity (m/s^2): {}".format(sensor.gravity))
-        print()
-    except RuntimeError as e:
-        print(e)
+    print("Accelerometer (m/s^2): {}".format(sensor.acceleration))
+    print("Magnetometer (microteslas): {}".format(sensor.magnetic))
+    print("Gyroscope (rad/sec): {}".format(sensor.gyro))
+    print("Euler angle: {}".format(sensor.euler))
+    print("Quaternion: {}".format(sensor.quaternion))
+    print("Linear acceleration (m/s^2): {}".format(sensor.linear_acceleration))
+    print("Gravity (m/s^2): {}".format(sensor.gravity))
+    print()
 
     time.sleep(1)


### PR DESCRIPTION
So I tried a bunch of different ways involving checking how many bytes were in waiting, but in the end, just making the time.sleep smaller and adding a try/except loop was the fastest and most stable way to do it.