### PR TITLE
Update README to use correct BNO055 class for I2C

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Once you have the I2C object, you can create the sensor object:
 
 .. code:: python
 
-    sensor = adafruit_bno055.BNO055(i2c)
+    sensor = adafruit_bno055.BNO055_I2C(i2c)
 
 
 And then you can start reading the measurements:


### PR DESCRIPTION
Using the `BNO055` class as written in the README results in a NotImplementedError. For the I2C example, the class `BNO055_I2C` needs to be used.