### PR TITLE
Fixed the operation mode reading issue

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -299,7 +299,7 @@ class BNO055:  # pylint: disable=too-many-public-methods
            is calculated from accelerometer, gyroscope and the magnetometer.
 
         """
-        return self._read_register(_MODE_REGISTER)
+        return ( self._read_register(_MODE_REGISTER) & 0x00001111 ) # Datasheet Table 4-2
 
     @mode.setter
     def mode(self, new_mode):

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -299,7 +299,7 @@ class BNO055:  # pylint: disable=too-many-public-methods
            is calculated from accelerometer, gyroscope and the magnetometer.
 
         """
-        return ( self._read_register(_MODE_REGISTER) & 0x00001111 ) # Datasheet Table 4-2
+        return ( self._read_register(_MODE_REGISTER) & 0b00001111 ) # Datasheet Table 4-2
 
     @mode.setter
     def mode(self, new_mode):

--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -299,7 +299,7 @@ class BNO055:  # pylint: disable=too-many-public-methods
            is calculated from accelerometer, gyroscope and the magnetometer.
 
         """
-        return ( self._read_register(_MODE_REGISTER) & 0b00001111 ) # Datasheet Table 4-2
+        return self._read_register(_MODE_REGISTER) & 0b00001111  # Datasheet Table 4-2
 
     @mode.setter
     def mode(self, new_mode):


### PR DESCRIPTION
This pull request will fix the issue https://github.com/adafruit/Adafruit_CircuitPython_BNO055/issues/79.

Only translate the lower 4 bits of the register OPR_MODE to the operation mode of the sensor.