### PR TITLE
Fixed deprecated method

### DIFF
--- a/examples/bno055_webgl_demo/server.py
+++ b/examples/bno055_webgl_demo/server.py
@@ -79,7 +79,7 @@ def read_bno():
             bno_data["quaternion"] = bno.quaternion
             bno_data["calibration"] = bno.calibration_status
             # Notify any waiting threads that the BNO state has been updated.
-            bno_changed.notifyAll()
+            bno_changed.notify_all()
         # Sleep until the next reading.
         time.sleep(1.0 / BNO_UPDATE_FREQUENCY_HZ)
 


### PR DESCRIPTION
notifyAll was replaced with notify_all. notifyAll still just goes to notify_all but it's deprecated so it made pylint mad
<img width="673" alt="Screen Shot 2022-01-20 at 12 56 08 PM" src="https://user-images.githubusercontent.com/33632497/150395298-abdb02d9-8271-4f87-b25f-9834803413b4.png">

https://docs.python.org/3/library/threading.html