### PR TITLE
compass mode example

### DIFF
--- a/examples/bno055_compass_mode.py
+++ b/examples/bno055_compass_mode.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 Tim Cocks for Adafruit Industries
+# SPDX-License-Identifier: MIT
+import math
+import time
+import board
+
+import adafruit_bno055
+
+i2c = board.I2C()
+
+sensor = adafruit_bno055.BNO055_I2C(i2c)
+
+# Set the sensor to compass mode
+sensor.mode = adafruit_bno055.COMPASS_MODE
+
+while True:
+    values = sensor.magnetic
+    print("Heading: " + str(180 + math.atan2(values[1], values[0]) * 180 / math.pi))
+    time.sleep(1)


### PR DESCRIPTION
@ladyada 
Resolves: #100 

Added the formula and code shared in that issue to the repo and did a quick test with picow and BNO055. I found that `magnetic` property is passing through the value from `_magnetic` so I had the example use the public one instead. 